### PR TITLE
Fix unicode lock

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
 <div class="container">
 <header class="masthead">
    <h3 class="masthead-title">
-     <a href="{{ site.url }}">&#x1F512 {{ site.title }}</a>
+     <a href="{{ site.url }}">&#x1F512; {{ site.title }}</a>
      <small>
        &nbsp;&nbsp;&nbsp;<a href="{{ site.url }}/about.html">About</a>
      </small>     


### PR DESCRIPTION
I was not seeing anything beside ActSecure.  I was not sure what the logo was until I looked at the page source.  According to this, there should be a lock: http://www.fileformat.info/info/unicode/char/1f512/index.htm
There needs to be a semicolon at the end of this code.