### PR TITLE
Blog post about dox defense fund

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,3 @@ date: 2017-03-12 21:02:00 -0500
 published: true
 ---
 ~~~
-
-## Todos
-- Get a better color scheme going on this thing.
-- Add content to "about"
-- Move the contact info to footer code in the default layout. 
-- Add "author" and "date" to the post layout. 

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ facebook_username: actsecure
 github_username:  actsecure
 gitter_username:  actsecure
 
-# projects in header index
+# Projects listed on index
 projects:
   - name: protest-guide
     url: https://github.com/actsecure/protest.guide
@@ -28,8 +28,6 @@ links:
     url: /blog
   - title: tags
     url: /tags
-  - title: about us
-    url: /about
 
 ################################################### Build settings
 markdown: kramdown

--- a/_posts/2017-12-02-dox-funds.md
+++ b/_posts/2017-12-02-dox-funds.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "Dox Defense Fund"
+published: true
+excerpt: "Donate to our Dox Defense Fund"
+tags:
+- doxxing
+- capitalism
+---
+
+Greetings, internet community!
+
+We're having a [fundraiser](https://www.youcaring.com/bostonsradicalleftactivists-1034010) to support our ongoing dox defense work. If we make our goal, we'll spend 10% of the total on infrastructure, but the rest is all going directly to activists.
+
+One of the hardest things about preventing doxxing is that if you miss one data broker in your cleanup efforts, and your attacker finds it, all of your efforts are wasted. And there are [a bajillion](https://www.privacyrights.org/data-brokers) data brokers out there. Naturally this leads to paranoia and overly obsessive security culture, which can be crippling to a movement. Luckily, you can cut down the amount of cleanup work that you personally have to do by [paying for a data scrubbing service](https://github.com/actsecure/resources/wiki/Clearing-data-brokers#3-pay-someone-else-to-clean-up-after-you). As with most capitalist solutions, many of the people who most need this cannot afford it, often for the same reasons that they need it.
+
+This is why we organize. There are *also* people in our communities who *can* afford these sorts of expenditures, but don't really need them. We think that the redistribution of wealth solution here is pretty straightforward. Help us protect some of the most vulnerable people in our community, who are nonetheless out on the front lines fighting for our collective liberation. If you'd like to contribute your time, skills, or potentially useful goods, we're up for that too. Feel free to [reach out]({{site.url}}/about).
+
+Love and struggle,
+ActSecure

--- a/about.html
+++ b/about.html
@@ -1,18 +1,7 @@
 ---
-layout: minimal
+layout: default
 title: "About ActSecure"
 permalink: /about/index.html
 description: "We can't really label this thing from inside of the thing."
 ---
 
-<img itemprop="image" class="img-rounded about_perfil" src="{{ site.url }}/assets/img/lock.png" alt="ActSecure">
-
-<h2>Projects</h2>
-
-<div class="aboutme">
-  <ul class="recent">
-    {% for project in site.projects %}
-    <li><a href="{{ project.url}}"><h3 class="project-name" itemprop="name">{{ project.name }}</h3></a></li>
-    {% endfor %}
-  </ul>
-</div>


### PR DESCRIPTION
Post is done. I used a link for "reach out" that I wanted to be a contact us sort of link, and I wanted it to be a page with the social media icons. Turns out that is way harder than it should be. I added #11 to make it easier to do this right, and for now the about page just looks like the index. Since this is confusing if you're just navigating around I've removed the about page from the nav. Once #11 is sorted we should put an actual blurb on that page as well.